### PR TITLE
Driver: allow to use placeholders in workloads and in driver YAML files

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -54,6 +54,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import io.openmessaging.benchmark.utils.PlaceHolderUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.openmessaging.benchmark.worker.DistributedWorkersEnsemble;
 import io.openmessaging.benchmark.worker.LocalWorker;
 import io.openmessaging.benchmark.worker.Worker;
+
+import static io.openmessaging.benchmark.utils.PlaceHolderUtils.readAndApplyPlaceholders;
 
 public class Benchmark {
 
@@ -114,7 +117,7 @@ public class Benchmark {
 
         if (arguments.workersFile != null) {
             log.info("Reading workers list from {}", arguments.workersFile);
-            arguments.workers = mapper.readValue(arguments.workersFile, Workers.class).workers;
+            arguments.workers = PlaceHolderUtils.readAndApplyPlaceholders(arguments.workersFile, Workers.class).workers;
         }
 
         // Dump configuration variables
@@ -124,8 +127,8 @@ public class Benchmark {
         for (String path : arguments.workloads) {
             File file = new File(path);
             String name = file.getName().substring(0, file.getName().lastIndexOf('.'));
-
-            workloads.put(name, mapper.readValue(file, Workload.class));
+            Workload workload = PlaceHolderUtils.readAndApplyPlaceholders(file, Workload.class);
+            workloads.put(name, workload);
         }
 
         log.info("Workloads: {}", writer.writeValueAsString(workloads));
@@ -143,27 +146,27 @@ public class Benchmark {
             arguments.drivers.forEach(driverConfig -> {
                 try {
                     File driverConfigFile = new File(driverConfig);
-                    DriverConfiguration driverConfiguration = mapper.readValue(driverConfigFile,
+                    DriverConfiguration driverConfiguration = PlaceHolderUtils.readAndApplyPlaceholders(driverConfigFile,
                             DriverConfiguration.class);
-		    if (arguments.consumerDriver != null) {
-			DriverConfiguration consumerDriverConfiguration = mapper.readValue(arguments.consumerDriver,
-			        DriverConfiguration.class);
-			driverConfiguration.name += ":";
-			driverConfiguration.name += consumerDriverConfiguration.name;
-		    }
+                    if (arguments.consumerDriver != null) {
+                        DriverConfiguration consumerDriverConfiguration = PlaceHolderUtils.readAndApplyPlaceholders(arguments.consumerDriver,
+                                DriverConfiguration.class);
+                        driverConfiguration.name += ":";
+                        driverConfiguration.name += consumerDriverConfiguration.name;
+                    }
                     log.info("--------------- WORKLOAD : {} --- DRIVER : {}---------------", workload.name,
                             driverConfiguration.name);
 
                     // Stop any left over workload
                     worker.stopAll();
 
-		    try {
-			// consumer driver is only used if the worker is a DistributedWorkersEnsemble
-			worker.initializeDriver(new File(driverConfig), arguments.consumerDriver);
-		    } catch (Exception e) {
-			log.error("Failed to initialize driver '{}' - Retry once", driverConfig);
-			worker.initializeDriver(new File(driverConfig), arguments.consumerDriver);
-		    }
+                    try {
+                        // consumer driver is only used if the worker is a DistributedWorkersEnsemble
+                        worker.initializeDriver(new File(driverConfig), arguments.consumerDriver);
+                    } catch (Exception e) {
+                        log.error("Failed to initialize driver '{}' - Retry once", driverConfig);
+                        worker.initializeDriver(new File(driverConfig), arguments.consumerDriver);
+                    }
 
                     WorkloadGenerator generator = new WorkloadGenerator(driverConfiguration.name, workload, worker);
 
@@ -188,13 +191,6 @@ public class Benchmark {
         });
 
         worker.close();
-    }
-
-    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    static {
-        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
     }
 
     private static final ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/PlaceHolderUtils.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/PlaceHolderUtils.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.text.StrSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class PlaceHolderUtils {
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    static {
+        mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(PlaceHolderUtils.class);
+
+    public static <T> T readAndApplyPlaceholders(File file, Class<T> clazz) throws IOException {
+        String content = readAndApplyPlaceholders(file);
+        return mapper.readValue(content, clazz);
+    }
+
+    public static String readAndApplyPlaceholders(File file) throws IOException  {
+        try (FileInputStream in = new FileInputStream(file)) {
+            String content = IOUtils.toString(in, StandardCharsets.UTF_8);
+            return readAndApplyPlaceholders(content);
+        }
+    }
+
+    public static String readAndApplyPlaceholders(String content) {
+        Map<String, String> variables = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+            variables.put(entry.getKey(), entry.getValue());
+        };
+        for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+            variables.put(entry.getKey() + "", entry.getValue() + "");
+        }
+        log.info("readAndApplyPlaceholders before {}", content);
+        StrSubstitutor sub = new StrSubstitutor(variables);
+        String result =  sub.replace(content);
+        log.info("readAndApplyPlaceholders result {}", result);
+        return result;
+    }
+}

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/PlaceHolderUtilsTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/PlaceHolderUtilsTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PlaceHolderUtilsTest {
+
+    @Test
+    public void testReplacePlaceHoldersWithDefault() {
+        // variable are non case sensitive
+        System.setProperty("testserviceURL", "http://thevalue");
+        String text = "serviceUrl: ${testServiceUrl:-http://test/com}";
+        String result = PlaceHolderUtils.readAndApplyPlaceholders(text);
+        assertEquals("serviceUrl: http://thevalue", result);
+
+        System.clearProperty("testserviceURL");
+        result = PlaceHolderUtils.readAndApplyPlaceholders(text);
+        assertEquals("serviceUrl: http://test/com", result);
+    }
+}

--- a/driver-pulsar/pulsar.yaml
+++ b/driver-pulsar/pulsar.yaml
@@ -22,7 +22,7 @@ driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
 
 # Pulsar client-specific configuration
 client:
-  serviceUrl: pulsar://localhost:6650
+  serviceUrl: ${pulsarServiceUrl:-pulsar://localhost:6650}
   httpUrl: http://localhost:8080
   ioThreads: 8
   connectionsPerBroker: 8


### PR DESCRIPTION
- allow to use ${placeholder} syntax in YAML files
- the placeholders are all the system properties and ENV variables, made lowercase

You can pass a default value using this syntax:
${placeholder:-DEFAULTVALUE}

This is the syntax supported by Apache Commons Text
https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/StringSubstitutor.html

