### PR TITLE
JMS: update Client to Starlight for JMS 2.1.0 and add examples for Server Side Selectors

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,7 @@ public class Benchmark {
             // Use local worker implementation
             worker = new LocalWorker();
         }
-
+        AtomicBoolean failed = new AtomicBoolean(false);
         workloads.forEach((workloadName, workload) -> {
             arguments.drivers.forEach(driverConfig -> {
                 try {
@@ -178,6 +179,7 @@ public class Benchmark {
                     generator.close();
                 } catch (Exception e) {
                     log.error("Failed to run the workload '{}' for driver '{}'", workload.name, driverConfig, e);
+                    failed.set(true);
                 } finally {
                     try {
                         worker.stopAll();
@@ -188,6 +190,10 @@ public class Benchmark {
         });
 
         worker.close();
+
+        if (failed.get()) {
+            System.exit(-1);
+        }
     }
 
     private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())

--- a/driver-jms/pom.xml
+++ b/driver-jms/pom.xml
@@ -48,7 +48,7 @@
 		  <groupId>com.datastax.oss</groupId>
                   <!-- the '-all' bundle contains a shaded version of Pulsar client-->
 		  <artifactId>pulsar-jms-all</artifactId>
-		  <version>2.0.0</version>
+		  <version>2.1.0</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.google.guava</groupId>

--- a/driver-jms/pom.xml
+++ b/driver-jms/pom.xml
@@ -46,8 +46,9 @@
 		</dependency>
 		<dependency>
 		  <groupId>com.datastax.oss</groupId>
-		  <artifactId>pulsar-jms</artifactId>
-		  <version>1.5.0</version>
+                  <!-- the '-all' bundle contains a shaded version of Pulsar client-->
+		  <artifactId>pulsar-jms-all</artifactId>
+		  <version>2.0.0</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.google.guava</groupId>

--- a/driver-jms/pulsar-jms-clientside-selectors.yaml
+++ b/driver-jms/pulsar-jms-clientside-selectors.yaml
@@ -21,7 +21,7 @@ name: JMS
 driverClass: io.openmessaging.benchmark.driver.jms.JMSBenchmarkDriver
 
 connectionFactoryClassName: com.datastax.oss.pulsar.jms.PulsarConnectionFactory
-connectionFactoryConfigurationParam: '{"brokerServiceUrl": "pulsar://localhost:6650", "jms.enableClientSideEmulation": "true", "webServiceUrl": "http://localhost:8080", "producerConfig":{"blockIfQueueFull":"true"}}'
+connectionFactoryConfigurationParam: '{"brokerServiceUrl": "pulsar://localhost:6650", "jms.enableClientSideEmulation": "true", "webServiceUrl": "http://localhost:8080", "producerConfig":{"blockIfQueueFull":"true","batchingEnabled":"true"}}'
 use20api: true
 
 # add a property to every message

--- a/driver-jms/pulsar-jms-serverside-selectors.yaml
+++ b/driver-jms/pulsar-jms-serverside-selectors.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: JMS
+driverClass: io.openmessaging.benchmark.driver.jms.JMSBenchmarkDriver
+
+connectionFactoryClassName: com.datastax.oss.pulsar.jms.PulsarConnectionFactory
+connectionFactoryConfigurationParam: '{"brokerServiceUrl": "pulsar://localhost:6650", "jms.useServerSideFiltering": "true", "webServiceUrl": "http://localhost:8080", "producerConfig":{"blockIfQueueFull":"true","batchingEnabled":"true"}}'
+use20api: true
+
+# add a property to every message
+properties:
+  - name: foo
+    value: bar
+
+# filter messages with a selector
+messageSelector: foo = 'bar'
+
+# JMS API do not provide functions to admin the cluster
+# So we are going to delegate the initialization to another specific Driver
+delegateForAdminOperationsClassName: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+
+# Pulsar specific configuration
+# the code that handles this configuration is the PulsarBenchmarkDriver
+client:
+  serviceUrl: pulsar://localhost:6650
+  httpUrl: http://localhost:8080
+  clusterName: local
+  namespacePrefix: public/default
+  topicType: persistent
+  persistence:
+    ensembleSize: 1
+    writeQuorum: 1
+    ackQuorum: 1
+    deduplicationEnabled: false
+producer:
+  blockIfQueueFull: true
+  pendingQueueSize: 10000


### PR DESCRIPTION
Summary of changes:
- Updated JMS client to 2.1.0
- Use "shaded" version, in order to allow to have a Pulsar version different from the one bundled with the Pulsar Driver (currently 2.8.x)
- Add a new example about how to add enable server side filtering
