### PR TITLE
Change to do performance checks for multiple jms selectors

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -45,6 +45,12 @@ public class Workload {
 
     public int consumerPerSubscription;
 
+    /**
+     * For some testing we use a subscription for a selector. We craft these to consume messages so that each message
+     * is consumed by only one subscription. This config controls the backlog calculations.
+     */
+    public boolean subscriptionsAreSelectors = false;
+
     public int producerRate;
     /**
      * If the producerRate = 0, the generator will slowly grow producerRate to find the maximum balanced rate

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -46,10 +46,11 @@ public class Workload {
     public int consumerPerSubscription;
 
     /**
-     * For some testing we use a subscription for a selector. We craft these to consume messages so that each message
-     * is consumed by only one subscription. This config controls the backlog calculations.
+     * For some testing we apply a filter subscriptions and the subscription won't
+     * receive all the messages.
+     * This config controls the backlog calculations.
      */
-    public boolean subscriptionsAreSelectors = false;
+    public int messageRateReceivedForSubscription = 100;
 
     public int producerRate;
     /**

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -84,7 +84,7 @@ public class WorkloadGenerator implements AutoCloseable {
 	    // Pause to allow brokers to assign topic ownership (Pulsar async issues
 	    timer = new Timer();
 	    try {
-		Thread.sleep(5000);
+		Thread.sleep(10000);
 	    } catch (InterruptedException e) {
 		throw new RuntimeException(e);
 	    }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -168,14 +168,35 @@ public class WorkloadGenerator implements AutoCloseable {
         return result;
     }
 
+    private long computeExpectedInitialBacklog(int numTopics) {
+        return computeBacklog(1, 0) * numTopics;
+    }
+
+    private long computeBacklog(long messagesSent, long messagesReceived) {
+        // each subscription is supposed to receive all the messages
+        long overallBacklog = workload.subscriptionsPerTopic * messagesSent;
+
+        // apply filters
+        long filteredBacklog = (overallBacklog * workload.messageRateReceivedForSubscription) / 100;
+
+        // remaining messages
+        long currentBacklogSize = filteredBacklog - messagesReceived;
+
+
+        log.debug("computeBacklog: sent {} subsPerTopic {} rate {}% received {} backlog {}",
+                messagesSent, workload.subscriptionsPerTopic, workload.messageRateReceivedForSubscription,
+                messagesReceived, currentBacklogSize);
+
+        return currentBacklogSize;
+    }
+
     private void ensureTopicsAreReady() throws IOException {
-        log.info("Waiting for consumers to be ready");
+        long expectedMessages = computeExpectedInitialBacklog(workload.producersPerTopic * workload.topics);
+        log.info("Waiting for consumers to be ready ({} messages to be received)", expectedMessages);
         // This is work around the fact that there's no way to have a consumer ready in Kafka without first publishing
         // some message on the topic, which will then trigger the partitions assignment to the consumers
 
-        int expectedMessages = workload.topics * (workload.subscriptionsAreSelectors ? 1 : workload.subscriptionsPerTopic);
-
-        // In this case we just publish 1 message and then wait for consumers to receive the data
+        // In this case we just publish 1 message on each producer and then wait for consumers to receive the data
         worker.probeProducers();
 
 	while (true) {
@@ -358,8 +379,7 @@ public class WorkloadGenerator implements AutoCloseable {
         while (true) {
 	    // Retrieve stats and calculate the current backlog in messages
             CountersStats stats = worker.getCountersStats();
-            long currentBacklogSize = (workload.subscriptionsAreSelectors ? 1 : workload.subscriptionsPerTopic) *
-		stats.messagesSent - stats.messagesReceived;
+            long currentBacklogSize = computeBacklog(stats.messagesSent, stats.messagesReceived);
 
             if (currentBacklogSize >= requestedBacklogSize) {
 		break;
@@ -401,8 +421,7 @@ public class WorkloadGenerator implements AutoCloseable {
 
         while (true) {
             CountersStats stats = worker.getCountersStats();
-            double currentBacklog = (workload.subscriptionsAreSelectors ? 1 : workload.subscriptionsPerTopic) *
-		stats.messagesSent - stats.messagesReceived;
+            double currentBacklog = computeBacklog(stats.messagesSent, stats.messagesReceived);
             if (currentBacklog <= acceptableBacklog) {
                 log.info("--- Completed backlog draining ---");
                 needToWaitForBacklogDraining = false;
@@ -457,8 +476,7 @@ public class WorkloadGenerator implements AutoCloseable {
             double consumeRate = stats.messagesReceived / elapsed;
             double consumeThroughput = stats.bytesReceived / elapsed / 1024 / 1024;
 
-            long currentBacklog = (workload.subscriptionsAreSelectors ? 1 : workload.subscriptionsPerTopic) *
-		stats.totalMessagesSent - stats.totalMessagesReceived;
+            long currentBacklog = computeBacklog(stats.totalMessagesSent, stats.totalMessagesReceived);
 
             log.info(
                     "Pub rate {} msg/s / {} MB/s | Cons rate {} msg/s / {} MB/s | Backlog: {} K | Pub Latency (ms) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {}",

--- a/driver-jms/pulsar-jms-2-selectors.yaml
+++ b/driver-jms/pulsar-jms-2-selectors.yaml
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: JMS
+driverClass: io.openmessaging.benchmark.driver.jms.JMSBenchmarkDriver
+
+connectionFactoryClassName: com.datastax.oss.pulsar.jms.PulsarConnectionFactory
+connectionFactoryConfigurationParam: '{"brokerServiceUrl": "pulsar://localhost:6650", "webServiceUrl": "http://localhost:8080", "jms.useServerSideFiltering": "true", "producerConfig":{"blockIfQueueFull":"true","batchingEnabled":"false"}}'
+use20api: true
+
+properties:
+  - name: EventType
+    value: Test
+  - name: AAA
+    value: A
+    every: 0
+    of: 2
+  - name: AAA
+    value: B
+    every: 1
+    of: 2
+messageSelectors:
+  - selector: AAA='A'
+  - selector: AAA='B'
+
+# JMS API do not provide functions to admin the cluster
+# So we are going to delegate the initialization to another specific Driver
+delegateForAdminOperationsClassName: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+
+# Pulsar specific configuration
+# the code that handles this configuration is the PulsarBenchmarkDriver
+client:
+  serviceUrl: pulsar://localhost:6650
+  httpUrl: http://localhost:8080
+  clusterName: local
+  namespacePrefix: benchmark/ns
+  topicType: persistent
+  persistence:
+    ensembleSize: 3
+    writeQuorum: 3
+    ackQuorum: 2
+    deduplicationEnabled: false
+  tlsAllowInsecureConnection: false
+  tlsEnableHostnameVerification: false
+  tlsTrustCertsFilePath:
+  authentication:
+    plugin:
+    data:
+producer:
+  batchingEnabled: false
+  batchingMaxPublishDelayMs: 1
+  blockIfQueueFull: true
+  pendingQueueSize: 10000

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkDriver.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkDriver.java
@@ -63,7 +63,7 @@ public class JMSBenchmarkDriver implements BenchmarkDriver {
     @Override
     public void initialize(File configurationFile, StatsLogger statsLogger) throws IOException {
         this.config = readConfig(configurationFile);
-	this.selectors = config.messageSelectors;
+        this.selectors = config.messageSelectors;
         log.info("JMS driver configuration: {}", writer.writeValueAsString(config));
 
         if (config.delegateForAdminOperationsClassName != null && !config.delegateForAdminOperationsClassName.isEmpty()) {
@@ -167,7 +167,8 @@ public class JMSBenchmarkDriver implements BenchmarkDriver {
         try {
             String selector = config.messageSelector != null && !config.messageSelector.isEmpty() ? config.messageSelector : null;
             if (selectors != null && selectors.size() > 0) {
-                int num_selector = Integer.parseInt(subscriptionName.substring(4,6)) % selectors.size();
+                log.info("Subscription id: {}; size: {}", subscriptionName.substring(4,7), selectors.size());
+                int num_selector = Integer.parseInt(subscriptionName.substring(4,7)) % selectors.size();
                 selector = selectors.get(num_selector).selector;
                 log.info("Choosing selector {} for subscription {} gives: {}", num_selector, subscriptionName, selector);
             }

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkDriver.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkDriver.java
@@ -166,7 +166,7 @@ public class JMSBenchmarkDriver implements BenchmarkDriver {
                     ConsumerCallback consumerCallback) {
         try {
             String selector = config.messageSelector != null && !config.messageSelector.isEmpty() ? config.messageSelector : null;
-            if ( selectors != null ) {
+            if (selectors != null && selectors.size() > 0) {
                 int num_selector = Integer.parseInt(subscriptionName.substring(4,6)) % selectors.size();
                 selector = selectors.get(num_selector).selector;
                 log.info("Choosing selector {} for subscription {} gives: {}", num_selector, subscriptionName, selector);

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkDriver.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkDriver.java
@@ -177,6 +177,7 @@ public class JMSBenchmarkDriver implements BenchmarkDriver {
             Destination destination = buildDestination(config, session, topic);
             MessageConsumer consumer;
             if (config.use20api) {
+                log.info("buildingConsumer of type {} on destination {}", config.consumerType, destination);
                 switch (config.consumerType) {
                     case SharedDurableConsumer:
                         if (config.destinationType != JMSConfig.DestinationType.Topic) {
@@ -202,7 +203,7 @@ public class JMSBenchmarkDriver implements BenchmarkDriver {
                 // but it is not supported in Confluent Kafka JMS client
                 consumer = session.createConsumer(destination, selector);
             }
-            return CompletableFuture.completedFuture(new JMSBenchmarkConsumer(connection, session, consumer, consumerCallback, config.use20api));
+            return CompletableFuture.completedFuture(new JMSBenchmarkConsumer(connection, session, consumer, consumerCallback, config.use20api, config.errorOnRedelivered));
         } catch (Exception err) {
             log.error("Failed to createConsumer '{}' for '{}'", subscriptionName, topic, err);
             CompletableFuture<BenchmarkConsumer> res = new CompletableFuture<>();

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
@@ -20,6 +20,7 @@ package io.openmessaging.benchmark.driver.jms;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -46,13 +47,16 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
     private final MessageProducer producer;
     private final boolean useAsyncSend;
     private long count;
+    private final HashMap<String,Integer> counters;
     private final List<JMSConfig.AddProperty> properties;
+    private final Integer zero = new Integer(0);
     public JMSBenchmarkProducer(Session session, Destination destination, boolean useAsyncSend, List<JMSConfig.AddProperty> properties) throws Exception {
         this.session = session;
         this.destination = destination;
         this.useAsyncSend = useAsyncSend;
         this.producer = session.createProducer(destination);
         this.count = 0;
+        this.counters = new HashMap<String,Integer>();
         this.properties = properties != null ? properties : Collections.emptyList();
     }
 
@@ -76,11 +80,21 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
             for (JMSConfig.AddProperty prop : properties) {
                 // allow for some metadata to be only for every n of m messages
                 if ( prop.of <= 0 || (count % prop.of) == prop.every ) {
+                    String name_value = prop.name+"="+prop.value;
+                    Integer n = counters.getOrDefault(name_value, zero) + 1;
+                    counters.put(name_value, n);
                     bytesMessage.setStringProperty(prop.name, prop.value);
                 }
             }
             // avoid eventual overflow
             count = (count + 1) % 1000000L;
+            if (count == 0) {
+                log.info("counters");
+                counters.forEach((meta, value) -> {
+                        log.info("{}={}", meta, value);
+                    });
+                counters.clear();
+            }
             // Add a timer property for end to end
             bytesMessage.setLongProperty("E2EStartMillis",System.currentTimeMillis());
             if (useAsyncSend) {

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/config/JMSConfig.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/config/JMSConfig.java
@@ -38,6 +38,11 @@ public class JMSConfig
 
     public boolean use20api;
 
+    /**
+     * Print a error on the log (of the worker) in case of duplicate message
+     */
+    public boolean errorOnRedelivered = true;
+
     public DestinationType destinationType = DestinationType.Topic;
 
     public ConsumerType consumerType = ConsumerType.SharedDurableConsumer;

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/config/JMSConfig.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/config/JMSConfig.java
@@ -32,6 +32,8 @@ public class JMSConfig
 
     public String messageSelector;
 
+    public List<AddSelectors> messageSelectors = new ArrayList<>();
+
     public List<AddProperty> properties = new ArrayList<>();
 
     public boolean use20api;
@@ -47,6 +49,12 @@ public class JMSConfig
     public static class AddProperty {
         public String name = "";
         public String value = "";
+        public int every = 0;
+        public int of = 0;
+    }
+
+    public static class AddSelectors {
+        public String selector;
     }
 
     public enum ConsumerType {

--- a/workloads/200k-2-selectors-10-topics-3-partitions-1k.yaml
+++ b/workloads/200k-2-selectors-10-topics-3-partitions-1k.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: 200k-10-topics-3-partitions-1k
+
+topics: 10
+partitionsPerTopic: 3
+messageSize: 1024
+#payloadFile: "payload/payload-100b.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
+
+messageRateReceivedForSubscription: 50
+subscriptionsPerTopic: 2
+consumerPerSubscription: 1
+producersPerTopic: 1
+
+# Discover max-sustainable rate
+producerRate: 200000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/workloads/400k-2-selectors-10-topics-3-partitions-1k.yaml
+++ b/workloads/400k-2-selectors-10-topics-3-partitions-1k.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: 400k-10-topics-3-partitions-1k
+
+topics: 10
+partitionsPerTopic: 3
+messageSize: 1024
+#payloadFile: "payload/payload-100b.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
+
+messageRateReceivedForSubscription: 50
+subscriptionsPerTopic: 2
+consumerPerSubscription: 1
+producersPerTopic: 1
+
+# Discover max-sustainable rate
+producerRate: 400000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15


### PR DESCRIPTION
Adds to `driver.yaml` two new constructions.

1. To properties optional `every` offset `of` modulus.
2. messageSelectors for multiple selectors.

Add to `workload.yaml` - `subscriptionsAreSelectors` which means that consumers for each selector should only consume messages meant to pass the given selector