### PR TITLE
[fix][artemis] Fix Artemis asynchronous send and acknowledgement configuration

### DIFF
--- a/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkDriver.java
+++ b/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkDriver.java
@@ -58,6 +58,11 @@ public class ArtemisBenchmarkDriver implements BenchmarkDriver {
             ServerLocator serverLocator = ActiveMQClient.createServerLocator(config.brokerAddress);
             // confirmation window size is in bytes, set to 1MB
             serverLocator.setConfirmationWindowSize(1024 * 1024);
+            // use asynchronous sending of messages where SendAcknowledgementHandler reports success/failure
+            serverLocator.setBlockOnDurableSend(false);
+            serverLocator.setBlockOnNonDurableSend(false);
+            // use async acknowledgement
+            serverLocator.setBlockOnAcknowledge(false);
             
             sessionFactory = serverLocator.createSessionFactory();
             session = sessionFactory.createSession();

--- a/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkDriver.java
+++ b/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkDriver.java
@@ -56,7 +56,8 @@ public class ArtemisBenchmarkDriver implements BenchmarkDriver {
         log.info("ActiveMQ Artemis driver configuration: {}", writer.writeValueAsString(config));
         try {
             ServerLocator serverLocator = ActiveMQClient.createServerLocator(config.brokerAddress);
-            serverLocator.setConfirmationWindowSize(1000);
+            // confirmation window size is in bytes, set to 1MB
+            serverLocator.setConfirmationWindowSize(1024 * 1024);
             
             sessionFactory = serverLocator.createSessionFactory();
             session = sessionFactory.createSession();

--- a/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkProducer.java
+++ b/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkProducer.java
@@ -18,23 +18,25 @@
  */
 package io.openmessaging.benchmark.driver.artemis;
 
+
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-
-import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler;
 
 public class ArtemisBenchmarkProducer implements BenchmarkProducer {
 
     private final ClientSession session;
     private final ClientProducer producer;
 
-    public ArtemisBenchmarkProducer(String address, ClientSessionFactory sessionFactory) throws ActiveMQException {
+    public ArtemisBenchmarkProducer(String address, ClientSessionFactory sessionFactory)
+            throws ActiveMQException {
         session = sessionFactory.createSession();
         producer = session.createProducer(address);
         session.start();
@@ -48,20 +50,29 @@ public class ArtemisBenchmarkProducer implements BenchmarkProducer {
 
     @Override
     public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
-        ClientMessage msg = session.createMessage(true /* durable */ );
+        ClientMessage msg = session.createMessage(true /* durable */);
         msg.setTimestamp(System.currentTimeMillis());
         msg.getBodyBuffer().writeBytes(payload);
 
         CompletableFuture<Void> future = new CompletableFuture<>();
         try {
-            producer.send(msg, message -> {
-                future.complete(null);
-            });
+            producer.send(
+                    msg,
+                    new SendAcknowledgementHandler() {
+                        @Override
+                        public void sendAcknowledged(Message message) {
+                            future.complete(null);
+                        }
+
+                        @Override
+                        public void sendFailed(Message message, Exception e) {
+                            future.completeExceptionally(e);
+                        }
+                    });
         } catch (ActiveMQException e) {
             future.completeExceptionally(e);
         }
 
         return future;
     }
-
 }


### PR DESCRIPTION
- see https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/org/apache/activemq/artemis/api/core/client/SendAcknowledgementHandler.html
  - configuring confirmation window is required for async message sending with Artemis
  - it is required to use non-blocking sessions for async sends

- The confirmation window size is in bytes, set to 1MB which is a more sensible value.

- configure async acknowledgements

matches upstream PR https://github.com/openmessaging/benchmark/pull/343