### PR TITLE
[feature] Add batchSize and useTransactions to Kafka Driver

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Date;
 import java.util.List;
@@ -76,7 +77,7 @@ public class Benchmark {
         boolean extraConsumers;
 
         @Parameter(description = "Workloads")//, required = true)
-        public List<String> workloads;
+        public List<String> workloads = new ArrayList<>();
     }
 
     public static void main(String[] args) throws Exception {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -256,12 +256,12 @@ public class LocalWorker implements Worker, ConsumerCallback {
                             byte[] payloadData = payloadCount == 0 ? firstPayload : payloads.get(r.nextInt(payloadCount));
                             final long sendTime = System.nanoTime();
                             producer.sendAsync(Optional.ofNullable(keyDistributor.next()), payloadData)
-                                    .thenRun(() -> {
-                                messagesSent.increment();
-                                totalMessagesSent.increment();
-                                messagesSentCounter.inc();
-                                bytesSent.add(payloadData.length);
-                                bytesSentCounter.add(payloadData.length);
+                                    .thenAcceptAsync((numberOfMessages) -> {
+                                messagesSent.add(numberOfMessages);
+                                totalMessagesSent.add(numberOfMessages);
+                                messagesSentCounter.add(numberOfMessages);
+                                bytesSent.add(payloadData.length * numberOfMessages);
+                                bytesSentCounter.add(payloadData.length * numberOfMessages);
 
                                 long latencyMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - sendTime);
                                 publishLatencyStats.registerSuccessfulEvent(latencyMicros, TimeUnit.MICROSECONDS);

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkProducer.java
@@ -30,8 +30,9 @@ public interface BenchmarkProducer extends AutoCloseable {
      *            the key associated with this message
      * @param payload
      *            the message payload
-     * @return a future that will be triggered when the message is successfully published
+     * @return a future that will be triggered when the message is successfully published,
+     *         the result is the number of messages sent
      */
-    CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload);
+    CompletableFuture<Integer> sendAsync(Optional<String> key, byte[] payload);
 
 }

--- a/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkProducer.java
+++ b/driver-artemis/src/main/java/io/openmessaging/benchmark/driver/artemis/ArtemisBenchmarkProducer.java
@@ -49,19 +49,19 @@ public class ArtemisBenchmarkProducer implements BenchmarkProducer {
     }
 
     @Override
-    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
+    public CompletableFuture<Integer> sendAsync(Optional<String> key, byte[] payload) {
         ClientMessage msg = session.createMessage(true /* durable */);
         msg.setTimestamp(System.currentTimeMillis());
         msg.getBodyBuffer().writeBytes(payload);
 
-        CompletableFuture<Void> future = new CompletableFuture<>();
+        CompletableFuture<Integer> future = new CompletableFuture<>();
         try {
             producer.send(
                     msg,
                     new SendAcknowledgementHandler() {
                         @Override
                         public void sendAcknowledged(Message message) {
-                            future.complete(null);
+                            future.complete(1);
                         }
 
                         @Override

--- a/driver-bookkeeper/src/main/java/io/openmessaging/benchmark/driver/bookkeeper/DlogBenchmarkProducer.java
+++ b/driver-bookkeeper/src/main/java/io/openmessaging/benchmark/driver/bookkeeper/DlogBenchmarkProducer.java
@@ -43,11 +43,11 @@ public class DlogBenchmarkProducer implements BenchmarkProducer {
     }
 
     @Override
-    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
+    public CompletableFuture<Integer> sendAsync(Optional<String> key, byte[] payload) {
         LogRecord record = new LogRecord(
             sequencer.nextId(), payload);
 
-        return writer.write(record).thenApply(dlsn -> null);
+        return writer.write(record).thenApply(dlsn -> 1);
     }
 
 }

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
@@ -66,8 +66,8 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
     }
 
     @Override
-    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
-        CompletableFuture<Void> res = new CompletableFuture<>();
+    public CompletableFuture<Integer> sendAsync(Optional<String> key, byte[] payload) {
+        CompletableFuture<Integer> res = new CompletableFuture<>();
         try
         {
             BytesMessage bytesMessage = session.createBytesMessage();
@@ -103,7 +103,7 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
                     @Override
                     public void onCompletion(Message message)
                     {
-                        res.complete(null);
+                        res.complete(1);
                     }
 
                     @Override
@@ -115,7 +115,7 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
                 });
             } else {
                 producer.send(bytesMessage);
-                res.complete(null);
+                res.complete(1);
             }
         } catch (JMSException err) {
             res.completeExceptionally(err);

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkTransactionProducer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkTransactionProducer.java
@@ -52,7 +52,7 @@ public class JMSBenchmarkTransactionProducer implements BenchmarkProducer {
     }
 
     @Override
-    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
+    public CompletableFuture<Integer> sendAsync(Optional<String> key, byte[] payload) {
         try
         {
             // start a new Session every time, we cannot share the same Session
@@ -72,13 +72,13 @@ public class JMSBenchmarkTransactionProducer implements BenchmarkProducer {
 	    // Add a timer property for end to end
 	    bytesMessage.setLongProperty("E2EStartMillis",System.currentTimeMillis());
             if (useAsyncSend) {
-                CompletableFuture<Void> res = new CompletableFuture<>();
+                CompletableFuture<Integer> res = new CompletableFuture<>();
                 producer.send(bytesMessage, new CompletionListener()
                 {
                     @Override
                     public void onCompletion(Message message)
                     {
-                        res.complete(null);
+                        res.complete(1);
                     }
 
                     @Override
@@ -98,21 +98,21 @@ public class JMSBenchmarkTransactionProducer implements BenchmarkProducer {
                         }
                     }
                     ensureClosed(producer, session);;
-                });
+                }).thenApply(___ -> 1);
             } else {
 
                 try {
                     producer.send(bytesMessage);
                     session.commit();
-                    CompletableFuture<Void> res = new CompletableFuture<>();
-                    res.complete(null);
+                    CompletableFuture<Integer> res = new CompletableFuture<>();
+                    res.complete(1);
                     return res;
                 } finally {
                     ensureClosed(producer, session);
                 }
             }
         } catch (JMSException err) {
-            CompletableFuture<Void> res = new CompletableFuture<>();
+            CompletableFuture<Integer> res = new CompletableFuture<>();
             res.completeExceptionally(err);
             return res;
         }

--- a/driver-kafka/kafka.yaml
+++ b/driver-kafka/kafka.yaml
@@ -18,6 +18,9 @@
 #
 
 
+batchSize: 1
+useTransactions: false
+
 name: Kafka
 driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
@@ -32,4 +32,7 @@ public class Config {
     public String producerConfig;
 
     public String consumerConfig;
+
+    public int batchSize = 1;
+    public boolean useTransactions;
 }

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -137,7 +137,10 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
     @Override
     public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
         KafkaProducer<String, byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
-        BenchmarkProducer benchmarkProducer = new KafkaBenchmarkProducer(kafkaProducer, topic);
+        BenchmarkProducer benchmarkProducer = new KafkaBenchmarkProducer(kafkaProducer, topic, config.batchSize, config.useTransactions);
+        if (config.useTransactions) {
+            kafkaProducer.initTransactions();
+        }
         try {
             // Add to producer list to close later
             producers.add(benchmarkProducer);

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkProducer.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkProducer.java
@@ -40,13 +40,13 @@ public class PulsarBenchmarkProducer implements BenchmarkProducer {
     }
 
     @Override
-    public CompletableFuture<Void> sendAsync(Optional<String> key, byte[] payload) {
+    public CompletableFuture<Integer> sendAsync(Optional<String> key, byte[] payload) {
         TypedMessageBuilder<byte[]> msgBuilder = producer.newMessage().value(payload);
         if (key.isPresent()) {
             msgBuilder.key(key.get());
         }
 
-        return msgBuilder.sendAsync().thenApply(msgId -> null);
+        return msgBuilder.sendAsync().thenApply(msgId -> 1);
     }
 
 }


### PR DESCRIPTION
Modifications:
- add batchSize to the "Kafka Driver"
- add preliminary support for "useTransactions"

While batchSize is already usable, useTransactions leads to very bad performances because using transaction require "blocking" and this slows down OMB, that is designed for async sends.


Setting batchSize to a value higher than 1 leads to a great performance improvement in my env, probably because we can leverage the batching feature of the Kafka Producer.