### PR TITLE
[feature] Kafka driver: allow to run multiple concurrent transactions

### DIFF
--- a/driver-kafka/kafka.yaml
+++ b/driver-kafka/kafka.yaml
@@ -17,12 +17,14 @@
 # under the License.
 #
 
-
-batchSize: 1
-useTransactions: false
-
 name: Kafka
 driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
+
+
+# Producer workload configuration
+batchSize: 1
+useTransactions: false
+maxConcurrentTransactions: 100
 
 # Kafka client-specific configuration
 replicationFactor: 3

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
@@ -35,4 +35,6 @@ public class Config {
 
     public int batchSize = 1;
     public boolean useTransactions;
+
+    public int maxConcurrentTransactions = 1;
 }

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -136,17 +136,12 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
-        KafkaProducer<String, byte[]> kafkaProducer = new KafkaProducer<>(producerProperties);
-        BenchmarkProducer benchmarkProducer = new KafkaBenchmarkProducer(kafkaProducer, topic, config.batchSize, config.useTransactions);
-        if (config.useTransactions) {
-            kafkaProducer.initTransactions();
-        }
         try {
+            BenchmarkProducer benchmarkProducer = new KafkaBenchmarkProducer(config, producerProperties, topic);
             // Add to producer list to close later
             producers.add(benchmarkProducer);
             return CompletableFuture.completedFuture(benchmarkProducer);
         } catch (Throwable t) {
-            kafkaProducer.close();
             CompletableFuture<BenchmarkProducer> future = new CompletableFuture<>();
             future.completeExceptionally(t);
             return future;


### PR DESCRIPTION
Motivation:
one KafkaProducer can handle only 1 transaction at a time


Modifications:
 - introduce maxConcurrentTransactions in the KafkaDriver
 - in case of useTransaction=true we create a "pool" of KafkaProducers
 - then the send completes we commit and then we return the Producer to the pool