### PR TITLE
Add support for testing Astra Flink with Connector Testing Mode

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -25,6 +25,8 @@ public class Workload {
     /** Number of partitions each topic will contain */
     public int partitionsPerTopic;
 
+    public boolean ensureTopicsAreReady = true;
+
     public KeyDistributorType keyDistributor = KeyDistributorType.NO_KEY;
 
     public int messageSize;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -82,7 +82,7 @@ public class WorkloadGenerator implements AutoCloseable {
     public TestResult run() throws Exception {
         TestResult result = null;
         try {
-	    Timer timer = new Timer();
+            Timer timer = new Timer();
             List<String> topics = worker.createTopics(new TopicsInfo(workload.topics, workload.partitionsPerTopic));
             log.info("Created {} topics in {} ms", topics.size(), timer.elapsedMillis());
             for (String topic: topics) {
@@ -212,6 +212,7 @@ public class WorkloadGenerator implements AutoCloseable {
     }
 
     private void ensureTopicsAreReady() throws IOException {
+        if ( !workload.ensureTopicsAreReady ) return;
         int counter = 0;
         long expectedMessages = computeExpectedInitialBacklog(workload.producersPerTopic * workload.topics);
         log.info("Waiting for consumers to be ready ({} messages to be received)", expectedMessages);

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-api/pom.xml
+++ b/driver-api/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-artemis/pom.xml
+++ b/driver-artemis/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-bookkeeper/pom.xml
+++ b/driver-bookkeeper/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-jms/pom.xml
+++ b/driver-jms/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-kafka/pom.xml
+++ b/driver-kafka/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>driver-kafka</artifactId>

--- a/driver-nats-streaming/pom.xml
+++ b/driver-nats-streaming/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-nats/pom.xml
+++ b/driver-nats/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-nsq/pom.xml
+++ b/driver-nsq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-pulsar/astra-flink.yaml
+++ b/driver-pulsar/astra-flink.yaml
@@ -20,12 +20,12 @@ driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
 client:
   astraStreaming: true
   connectorTesting: true
-  serviceUrl: ${pulsarServiceUrl:-pulsar+ssl://pulsar-aws-useast2.staging.streaming.datastax.com:6651}
-  httpUrl: ${pulsarAdminUrl:-https://pulsar-aws-useast2.api.staging.streaming.datastax.com}
+  serviceUrl: pulsar+ssl://pulsar-aws-useast2.dev.streaming.datastax.com:6651
+  httpUrl: https://pulsar-aws-useast2.api.dev.streaming.datastax.com
   ioThreads: 8
   connectionsPerBroker: 8
   clusterName: ${astraCluster:-dev0}
-  namespacePrefix: ${astraTenant:-dave-fisher-flink}/${astraNamespace:-default}
+  namespacePrefix: dave-fisher-flink/default
   topicType: persistent
   persistence:
     ensembleSize: 3
@@ -41,7 +41,7 @@ client:
 
 # Producer configuration
 producer:
-  inputTopic: persistent://${astraTenant:-dave-fisher-flink}/${astraNamespace:-default}/persons
+  inputTopic: persistent://dave-fisher-flink/default/persons
   batchingEnabled: true
   batchingMaxPublishDelayMs: 1
   blockIfQueueFull: true
@@ -49,6 +49,6 @@ producer:
 
 # Consumer configuration
 consumer:
-  outputTopic: persistent://${astraTenant:-dave-fisher-flink}/${astraNamespace:-default}/persons-output
-  subscriptionType: Failover
+  outputTopic: persistent://dave-fisher-flink/default/persons-output
+  subscriptionType: Shared
   subscriptionMode: Durable

--- a/driver-pulsar/astra-flink.yaml
+++ b/driver-pulsar/astra-flink.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Pulsar
+driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+
+# Pulsar client-specific configuration
+client:
+  astraStreaming: true
+  connectorTesting: true
+  serviceUrl: ${pulsarServiceUrl:-pulsar+ssl://pulsar-aws-useast2.staging.streaming.datastax.com:6651}
+  httpUrl: ${pulsarAdminUrl:-https://pulsar-aws-useast2.api.staging.streaming.datastax.com}
+  ioThreads: 8
+  connectionsPerBroker: 8
+  clusterName: ${astraCluster:-dev0}
+  namespacePrefix: ${astraTenant:-dave-fisher-flink}/${astraNamespace:-default}
+  topicType: persistent
+  persistence:
+    ensembleSize: 3
+    writeQuorum: 3
+    ackQuorum: 2
+    deduplicationEnabled: false
+  tlsAllowInsecureConnection: false
+  tlsEnableHostnameVerification: false
+  tlsTrustCertsFilePath:
+  authentication:
+    plugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
+    data: token:${astraToken}
+
+# Producer configuration
+producer:
+  inputTopic: persistent://${astraTenant:-dave-fisher-flink}/${astraNamespace:-default}/persons
+  batchingEnabled: true
+  batchingMaxPublishDelayMs: 1
+  blockIfQueueFull: true
+  pendingQueueSize: 10000
+
+# Consumer configuration
+consumer:
+  outputTopic: persistent://${astraTenant:-dave-fisher-flink}/${astraNamespace:-default}/persons-output
+  subscriptionType: Failover
+  subscriptionMode: Durable

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarClientConfig.java
@@ -43,6 +43,8 @@ public class PulsarClientConfig {
 
     public boolean astraStreaming = false;
 
+    public boolean connectorTesting = false;
+
     public boolean tlsAllowInsecureConnection = false;
 
     public boolean tlsEnableHostnameVerification = false;

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarConsumerConfig.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarConsumerConfig.java
@@ -20,5 +20,5 @@ import org.apache.pulsar.client.api.SubscriptionType;
 public class PulsarConsumerConfig {
     public String subscriptionType = SubscriptionType.Failover.toString();
     public String subscriptionMode = SubscriptionMode.Durable.toString();
-
+    public String outputTopic;
 }

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarProducerConfig.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/config/PulsarProducerConfig.java
@@ -20,4 +20,6 @@ public class PulsarProducerConfig {
     public int batchingMaxPublishDelayMs = 1;
 
     public int pendingQueueSize = 1000;
+
+    public String inputTopic;
 }

--- a/driver-rabbitmq/pom.xml
+++ b/driver-rabbitmq/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>driver-rabbitmq</artifactId>
 

--- a/driver-rocketmq/pom.xml
+++ b/driver-rocketmq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-starlight-rabbitmq/pom.xml
+++ b/driver-starlight-rabbitmq/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>driver-starlight-rabbitmq</artifactId>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>0.0.3-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/payload/payload-20b.data
+++ b/payload/payload-20b.data
@@ -1,0 +1,1 @@
+{"name":"dave fish"}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
 	<groupId>io.openmessaging.benchmark</groupId>
 	<artifactId>messaging-benchmark</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<name>Messaging Benchmark</name>
 	<packaging>pom</packaging>
 

--- a/workloads/1-topic-2-partitions-20b.yaml
+++ b/workloads/1-topic-2-partitions-20b.yaml
@@ -13,10 +13,11 @@
 # under the License.
 #
 
-name: 1 topic / 6 partition / 100b
+name: 1-topic-2-partition-20b
 
 topics: 1
-partitionsPerTopic: 6
+partitionsPerTopic: 2
+ensureTopicsAreReady: false
 keyDistributor: "KEY_ROUND_ROBIN"
 messageSize: 20
 payloadFile: "payload/payload-20b.data"

--- a/workloads/1-topic-6-partition-20b.yaml
+++ b/workloads/1-topic-6-partition-20b.yaml
@@ -1,0 +1,28 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: 1 topic / 6 partition / 100b
+
+topics: 1
+partitionsPerTopic: 6
+keyDistributor: "KEY_ROUND_ROBIN"
+messageSize: 20
+payloadFile: "payload/payload-20b.data"
+subscriptionsPerTopic: 1
+consumerPerSubscription: 1
+producersPerTopic: 1
+producerRate: 5000
+consumerBacklogSizeGB: 0
+testDurationMinutes: ${ombTestDuration:-5}


### PR DESCRIPTION
1. Add connector testing mode to Pulsar Driver with pre-created producer and consumer topics.
2. Allow skipping the "Ensure Topics are REady" workload step.
3. Update to 0.0.3-SNAPSHOT