### PR TITLE
bump version to 0.0.4-SNAPSHOT and support JDK17

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -28,7 +28,7 @@
 
 	<properties>
 		<log4j.version>2.17.2</log4j.version>
-		<jackson.version>2.13.2</jackson.version>
+		<jackson.version>2.14.2</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -23,4 +23,4 @@ fi
 JVM_MEM="${JVM_MEM:--Xms4G -Xmx4G -XX:+UseG1GC}"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.Benchmark $*
+java -server -cp $CLASSPATH $JVM_MEM --add-opens java.base/sun.net=ALL-UNNAMED  --add-opens java.base/java.lang=ALL-UNNAMED io.openmessaging.benchmark.Benchmark $*

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -23,4 +23,4 @@ fi
 JVM_MEM="${JVM_MEM:--Xms4G -Xmx4G -XX:+UseG1GC}"
 # JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-exec java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.worker.BenchmarkWorker $*
+exec java -server -cp $CLASSPATH $JVM_MEM --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED io.openmessaging.benchmark.worker.BenchmarkWorker $*

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-api/pom.xml
+++ b/driver-api/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-artemis/pom.xml
+++ b/driver-artemis/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-bookkeeper/pom.xml
+++ b/driver-bookkeeper/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-jms/pom.xml
+++ b/driver-jms/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -44,7 +44,7 @@
 		  <groupId>com.datastax.oss</groupId>
                   <!-- the '-all' bundle contains a shaded version of Pulsar client-->
 		  <artifactId>pulsar-jms-all</artifactId>
-		  <version>3.2.1</version>
+		  <version>4.0.0</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.google.guava</groupId>

--- a/driver-kafka/pom.xml
+++ b/driver-kafka/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>driver-kafka</artifactId>

--- a/driver-nats-streaming/pom.xml
+++ b/driver-nats-streaming/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-nats/pom.xml
+++ b/driver-nats/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-nsq/pom.xml
+++ b/driver-nsq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-pulsar/pom.xml
+++ b/driver-pulsar/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/driver-rabbitmq/pom.xml
+++ b/driver-rabbitmq/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>driver-rabbitmq</artifactId>
 

--- a/driver-rocketmq/pom.xml
+++ b/driver-rocketmq/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>messaging-benchmark</artifactId>
         <groupId>io.openmessaging.benchmark</groupId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/driver-starlight-rabbitmq/pom.xml
+++ b/driver-starlight-rabbitmq/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>driver-starlight-rabbitmq</artifactId>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
-		<version>0.0.3-SNAPSHOT</version>
+		<version>0.0.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
 	<groupId>io.openmessaging.benchmark</groupId>
 	<artifactId>messaging-benchmark</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.4-SNAPSHOT</version>
 	<name>Messaging Benchmark</name>
 	<packaging>pom</packaging>
 
@@ -58,7 +58,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<bookkeeper.version>4.14.0</bookkeeper.version>
-                <pulsar.version>2.10.3</pulsar.version>
+                <pulsar.version>3.0.0</pulsar.version>
                 <pulsar.groupId>org.apache.pulsar</pulsar.groupId>
 	</properties>
 
@@ -117,13 +117,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2.1</version>
+			<version>2.14.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>2.13.2</version>
+			<version>2.14.2</version>
 		</dependency>
 		<dependency>
 		  <groupId>io.netty</groupId>


### PR DESCRIPTION
Changes to update versions and go to JDK17

Summary:
- bump version to 0.0.4-SNAPSHOT
- add --add-opens to better support JDK17
- update jackson to 2.14.2
