### PR TITLE
Fix bookkeeper deploy.yaml using unclaimed S3 bucket

### DIFF
--- a/driver-bookkeeper/deploy/deploy.yaml
+++ b/driver-bookkeeper/deploy/deploy.yaml
@@ -55,12 +55,12 @@
         serviceUrl: "pulsar://{{ hostvars[groups['bookkeeper'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['bookkeeper'][0]].private_ip }}:8080/"
         dlogUri: "distributedlog://{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}/streams"
-        pulsarVersion: "2.0.0-incubating-SNAPSHOT"
+        pulsarVersion: "2.1.1-incubating"
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package
       unarchive:
-        src: "https://s3.amazonaws.com/pulsar-testing/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
+        src: "https://archive.apache.org/dist/pulsar/pulsar-{{ pulsarVersion }}/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz"
         remote_src: yes
         dest: /opt/pulsar
         extra_opts: ["--strip-components=1"]


### PR DESCRIPTION
Fixes: [AS-4294](https://datastax.jira.com/browse/AS-4294)

Updated URL for pulsar binary to [archive.apache.org](https://archive.apache.org/dist/pulsar/) instead of unclaimed S3 bucket 

[AS-4294]: https://datastax.jira.com/browse/AS-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ